### PR TITLE
Set "Connection: close" header for keep-alived requests after listener is closed

### DIFF
--- a/grace.go
+++ b/grace.go
@@ -53,6 +53,13 @@ type Listener interface {
 	File() (f *os.File, err error)
 }
 
+type ClosingListener interface {
+	Listener
+
+	// Whether the listener has been closed
+	Closed() bool
+}
+
 type listener struct {
 	Listener
 	closed      bool
@@ -102,6 +109,12 @@ func (l *listener) Close() error {
 	return err
 }
 
+func (l *listener) Closed() bool {
+	l.closedMutex.RLock()
+	defer l.closedMutex.RUnlock()
+	return l.closed
+}
+
 func (l *listener) Accept() (net.Conn, error) {
 	// Presume we'll accept and decrement in defer if we don't. If we did this
 	// after a successful accept we would have a race condition where we may end
@@ -116,12 +129,9 @@ func (l *listener) Accept() (net.Conn, error) {
 		}
 	}()
 
-	l.closedMutex.RLock()
-	if l.closed {
-		l.closedMutex.RUnlock()
+	if l.Closed() {
 		return nil, ErrAlreadyClosed
 	}
-	l.closedMutex.RUnlock()
 
 	c, err := l.Listener.Accept()
 	if err != nil {
@@ -133,12 +143,9 @@ func (l *listener) Accept() (net.Conn, error) {
 		// to handoff to a child as part of our restart process. In this scenario
 		// we want to treat the timeout the same as a Close.
 		if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
-			l.closedMutex.RLock()
-			if l.closed {
-				l.closedMutex.RUnlock()
+			if l.Closed() {
 				return nil, ErrAlreadyClosed
 			}
-			l.closedMutex.RUnlock()
 		}
 		return nil, err
 	}

--- a/gracehttp/http_test.go
+++ b/gracehttp/http_test.go
@@ -171,7 +171,6 @@ func (h *harness) SendOne(dialgroup *sync.WaitGroup, url string, pid int) {
 	debug("Send %02d pid=%d url=%s", count, pid, url)
 	client := &http.Client{
 		Transport: &http.Transport{
-			DisableKeepAlives: true,
 			Dial: func(network, addr string) (net.Conn, error) {
 				defer func() {
 					time.Sleep(50 * time.Millisecond)

--- a/gracehttp/testserver/testserver.go
+++ b/gracehttp/testserver/testserver.go
@@ -92,7 +92,6 @@ func main() {
 
 	// we have self signed certs
 	http.DefaultTransport = &http.Transport{
-		DisableKeepAlives: true,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},


### PR DESCRIPTION
Go continues to serve requests for open connections that are using keep-alive, so parent processes can stick around for hours if there's a persistent connection that makes repeated requests, even if a server's `ReadTimeout` is set to an appropriate value.

This seemed to be the cleanest, least intrusive way to force all keep-alived connections to close once the listener has closed. We've tested this with our Go HTTP services and it allows the old parent processes to die almost immediately, whereas before we'd sometimes have 6-12 old parents sitting around holding keep-alived connections.

I haven't figured out a great way to test this yet (tried several things without any luck), but I'm open to suggestions.
