### PR TITLE
Expose logger

### DIFF
--- a/gracehttp/testbin_test.go
+++ b/gracehttp/testbin_test.go
@@ -113,11 +113,6 @@ func testbinMain() {
 		},
 	}
 
-	err := flag.Set("gracehttp.log", "false")
-	if err != nil {
-		log.Fatalf("Error setting gracehttp.log: %s", err)
-	}
-
 	// print json to stderr once we can successfully connect to all three
 	// addresses. the ensures we only print the line once we're ready to serve.
 	go func() {
@@ -133,7 +128,7 @@ func testbinMain() {
 		}
 	}()
 
-	err = gracehttp.Serve(
+	err := gracehttp.Serve(
 		&http.Server{Addr: httpAddr, Handler: newHandler()},
 		httpsServer(httpsAddr),
 	)


### PR DESCRIPTION
This closes #13 and gives ability to set your own logger with your custom prefixes and other logic.

Done:
- New function `SetLogger` added to be able to set logger
- Flag `gracehttp.log` removed just not to confuse people with logs from nowhere