### PR TITLE
Add option for 'StartupHook'

### DIFF
--- a/gracehttp/http.go
+++ b/gracehttp/http.go
@@ -28,13 +28,13 @@ type option func(*app)
 
 // An app contains one or more servers and associated configuration.
 type app struct {
-	servers     []*http.Server
-	http        *httpdown.HTTP
-	net         *gracenet.Net
-	listeners   []net.Listener
-	sds         []httpdown.Server
-	startupHook func() error
-	errors      chan error
+	servers         []*http.Server
+	http            *httpdown.HTTP
+	net             *gracenet.Net
+	listeners       []net.Listener
+	sds             []httpdown.Server
+	preStartProcess func() error
+	errors          chan error
 }
 
 func newApp(servers []*http.Server) *app {
@@ -45,7 +45,7 @@ func newApp(servers []*http.Server) *app {
 		listeners: make([]net.Listener, 0, len(servers)),
 		sds:       make([]httpdown.Server, 0, len(servers)),
 
-		startupHook: func() error { return nil },
+		preStartProcess: func() error { return nil },
 		// 2x num servers for possible Close or Stop errors + 1 for possible
 		// StartProcess error.
 		errors: make(chan error, 1+(len(servers)*2)),
@@ -112,7 +112,7 @@ func (a *app) signalHandler(wg *sync.WaitGroup) {
 			a.term(wg)
 			return
 		case syscall.SIGUSR2:
-			err := a.startupHook()
+			err := a.preStartProcess()
 			if err != nil {
 				a.errors <- err
 			}
@@ -193,12 +193,12 @@ func Serve(servers ...*http.Server) error {
 	return a.run()
 }
 
-// StartupHook configures a callback to trigger during graceful restart
+// PreStartProcess configures a callback to trigger during graceful restart
 // directly before starting the successor process. This allows the current
 // process to release holds on resources that the new process will need.
-func StartupHook(hook func() error) option {
+func PreStartProcess(hook func() error) option {
 	return func(a *app) {
-		a.startupHook = hook
+		a.preStartProcess = hook
 	}
 }
 

--- a/gracehttp/http_test.go
+++ b/gracehttp/http_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	TEST_STARTUP_HOOK = iota
+	testPreStartProcess = iota
 )
 
 // Debug logging.
@@ -266,11 +266,11 @@ func TestComplexAgain(t *testing.T) {
 	h.Wait()
 }
 
-func TestStartupHook(t *testing.T) {
+func TestPreStartProcess(t *testing.T) {
 	t.Parallel()
-	debug("Started TestStartupHook")
+	debug("Started TestPreStartProcess")
 	h := newHarness(t)
-	h.serveOption = TEST_STARTUP_HOOK
+	h.serveOption = testPreStartProcess
 	debug("Initial Start")
 	h.Start()
 	debug("Send Request 1")
@@ -289,11 +289,11 @@ func TestStartupHook(t *testing.T) {
 	h.Wait()
 }
 
-func TestStartupHookAgain(t *testing.T) {
+func TestPreStartProcessAgain(t *testing.T) {
 	t.Parallel()
-	debug("Started TestStartupHookAgain")
+	debug("Started TestPreStartProcessAgain")
 	h := newHarness(t)
-	h.serveOption = TEST_STARTUP_HOOK
+	h.serveOption = testPreStartProcess
 	debug("Initial Start")
 	h.Start()
 	debug("Send Request 1")

--- a/gracehttp/http_test.go
+++ b/gracehttp/http_test.go
@@ -11,12 +11,17 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strconv"
 	"sync"
 	"syscall"
 	"testing"
 	"time"
 
 	"github.com/facebookgo/freeport"
+)
+
+const (
+	TEST_STARTUP_HOOK = iota
 )
 
 // Debug logging.
@@ -39,6 +44,7 @@ type harness struct {
 	newProcess        chan bool      // A bool is sent on start/restart.
 	requestCount      int
 	requestCountMutex sync.Mutex
+	serveOption       int
 }
 
 // Find 3 free ports and setup addresses.
@@ -60,7 +66,7 @@ func (h *harness) setupAddr() {
 // Start a fresh server and wait for pid updates on restart.
 func (h *harness) Start() {
 	h.setupAddr()
-	cmd := exec.Command(os.Args[0], "-http", h.httpAddr, "-https", h.httpsAddr)
+	cmd := exec.Command(os.Args[0], "-http", h.httpAddr, "-https", h.httpsAddr, "-testOption", strconv.Itoa(h.serveOption))
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
 		h.T.Fatal(err)
@@ -209,8 +215,9 @@ func (h *harness) Wait() {
 
 func newHarness(t *testing.T) *harness {
 	return &harness{
-		T:          t,
-		newProcess: make(chan bool),
+		T:           t,
+		newProcess:  make(chan bool),
+		serveOption: -1,
 	}
 }
 
@@ -241,6 +248,52 @@ func TestComplexAgain(t *testing.T) {
 	t.Parallel()
 	debug("Started TestComplex")
 	h := newHarness(t)
+	debug("Initial Start")
+	h.Start()
+	debug("Send Request 1")
+	h.SendRequest()
+	debug("Restart 1")
+	h.Restart()
+	debug("Send Request 2")
+	h.SendRequest()
+	debug("Restart 2")
+	h.Restart()
+	debug("Send Request 3")
+	h.SendRequest()
+	debug("Stopping")
+	h.Stop()
+	debug("Waiting")
+	h.Wait()
+}
+
+func TestStartupHook(t *testing.T) {
+	t.Parallel()
+	debug("Started TestStartupHook")
+	h := newHarness(t)
+	h.serveOption = TEST_STARTUP_HOOK
+	debug("Initial Start")
+	h.Start()
+	debug("Send Request 1")
+	h.SendRequest()
+	debug("Restart 1")
+	h.Restart()
+	debug("Send Request 2")
+	h.SendRequest()
+	debug("Restart 2")
+	h.Restart()
+	debug("Send Request 3")
+	h.SendRequest()
+	debug("Stopping")
+	h.Stop()
+	debug("Waiting")
+	h.Wait()
+}
+
+func TestStartupHookAgain(t *testing.T) {
+	t.Parallel()
+	debug("Started TestStartupHookAgain")
+	h := newHarness(t)
+	h.serveOption = TEST_STARTUP_HOOK
 	debug("Initial Start")
 	h.Start()
 	debug("Send Request 1")

--- a/gracehttp/testbin_test.go
+++ b/gracehttp/testbin_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/facebookgo/grace/gracehttp"
 )
 
-const STARTUP_HOOK_ENV = "GRACEHTTP_STARTUP_HOOK"
+const preStartProcessEnv = "GRACEHTTP_PRE_START_PROCESS"
 
 func TestMain(m *testing.M) {
 	const (
@@ -143,31 +143,31 @@ func testbinMain() {
 			log.Fatalf("Error in gracehttp.Serve: %s", err)
 		}
 	} else {
-		if testOption == TEST_STARTUP_HOOK {
-			switch os.Getenv(STARTUP_HOOK_ENV) {
+		if testOption == testPreStartProcess {
+			switch os.Getenv(preStartProcessEnv) {
 			case "":
-				err := os.Setenv(STARTUP_HOOK_ENV, "READY")
+				err := os.Setenv(preStartProcessEnv, "READY")
 				if err != nil {
-					log.Fatalf("testbin (first incarnation) could not set %v to 'ready': %v", STARTUP_HOOK_ENV, err)
+					log.Fatalf("testbin (first incarnation) could not set %v to 'ready': %v", preStartProcessEnv, err)
 				}
 			case "FIRED":
 				// all good, reset for next round
-				err := os.Setenv(STARTUP_HOOK_ENV, "READY")
+				err := os.Setenv(preStartProcessEnv, "READY")
 				if err != nil {
-					log.Fatalf("testbin (second incarnation) could not reset %v to 'ready': %v", STARTUP_HOOK_ENV, err)
+					log.Fatalf("testbin (second incarnation) could not reset %v to 'ready': %v", preStartProcessEnv, err)
 				}
 			case "READY":
 				log.Fatalf("failure to update startup hook before new process started")
 			default:
-				log.Fatalf("something strange happened with %v: it ended up as %v, which is not '', 'FIRED', or 'READY'", STARTUP_HOOK_ENV, os.Getenv(STARTUP_HOOK_ENV))
+				log.Fatalf("something strange happened with %v: it ended up as %v, which is not '', 'FIRED', or 'READY'", preStartProcessEnv, os.Getenv(preStartProcessEnv))
 			}
 
 			err := gracehttp.ServeWithOptions(
 				servers,
-				gracehttp.StartupHook(func() error {
-					err := os.Setenv(STARTUP_HOOK_ENV, "FIRED")
+				gracehttp.PreStartProcess(func() error {
+					err := os.Setenv(preStartProcessEnv, "FIRED")
 					if err != nil {
-						log.Fatalf("startup hook could not set %v to 'fired': %v", STARTUP_HOOK_ENV, err)
+						log.Fatalf("startup hook could not set %v to 'fired': %v", preStartProcessEnv, err)
 					}
 					return nil
 				}),

--- a/gracehttp/testbin_test.go
+++ b/gracehttp/testbin_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/facebookgo/grace/gracehttp"
 )
 
+const STARTUP_HOOK_ENV = "GRACEHTTP_STARTUP_HOOK"
+
 func TestMain(m *testing.M) {
 	const (
 		testbinKey   = "GRACEHTTP_TEST_BIN"
@@ -101,8 +103,10 @@ func httpsServer(addr string) *http.Server {
 
 func testbinMain() {
 	var httpAddr, httpsAddr string
+	var testOption int
 	flag.StringVar(&httpAddr, "http", ":48560", "http address to bind to")
 	flag.StringVar(&httpsAddr, "https", ":48561", "https address to bind to")
+	flag.IntVar(&testOption, "testOption", -1, "which option to test on ServeWithOptions")
 	flag.Parse()
 
 	// we have self signed certs
@@ -128,12 +132,50 @@ func testbinMain() {
 		}
 	}()
 
-	err := gracehttp.Serve(
+	servers := []*http.Server{
 		&http.Server{Addr: httpAddr, Handler: newHandler()},
 		httpsServer(httpsAddr),
-	)
-	if err != nil {
-		log.Fatalf("Error in gracehttp.Serve: %s", err)
+	}
+
+	if testOption == -1 {
+		err := gracehttp.Serve(servers...)
+		if err != nil {
+			log.Fatalf("Error in gracehttp.Serve: %s", err)
+		}
+	} else {
+		if testOption == TEST_STARTUP_HOOK {
+			switch os.Getenv(STARTUP_HOOK_ENV) {
+			case "":
+				err := os.Setenv(STARTUP_HOOK_ENV, "READY")
+				if err != nil {
+					log.Fatalf("testbin (first incarnation) could not set %v to 'ready': %v", STARTUP_HOOK_ENV, err)
+				}
+			case "FIRED":
+				// all good, reset for next round
+				err := os.Setenv(STARTUP_HOOK_ENV, "READY")
+				if err != nil {
+					log.Fatalf("testbin (second incarnation) could not reset %v to 'ready': %v", STARTUP_HOOK_ENV, err)
+				}
+			case "READY":
+				log.Fatalf("failure to update startup hook before new process started")
+			default:
+				log.Fatalf("something strange happened with %v: it ended up as %v, which is not '', 'FIRED', or 'READY'", STARTUP_HOOK_ENV, os.Getenv(STARTUP_HOOK_ENV))
+			}
+
+			err := gracehttp.ServeWithOptions(
+				servers,
+				gracehttp.StartupHook(func() error {
+					err := os.Setenv(STARTUP_HOOK_ENV, "FIRED")
+					if err != nil {
+						log.Fatalf("startup hook could not set %v to 'fired': %v", STARTUP_HOOK_ENV, err)
+					}
+					return nil
+				}),
+			)
+			if err != nil {
+				log.Fatalf("Error in gracehttp.Serve: %s", err)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Hiya!

First: thanks for grace, it is the bomb.

At $work we bumped into a situation where graceful restart was impeded by a resource the old process needed to release in order for the new one to start up successfully. In our specific case, there was an auxiliary HTTP server running on a different port that we needed to shut off before booting up the successor process: otherwise the port would still be in use. We needed to ensure the successor could start that auxiliary HTTP server because the application is an in-memory index, and it needs to receive data on that auxiliary server in order to warm up and be ready to serve queries on the primary HTTP server.

This PR introduces a second exported func, `ServeWithOptions`, which takes a slice of servers and varargs functional options (following the pattern from [here](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis)). The only option implemented at present is support for a `StartupHook`, which takes a `func() error` and calls that after receiving `SIGUSR2` but before starting the successor. This provides an opportunity to release holds on resources without the potential race of having another `SIGUSR2` handler.

This library has been stable for quite a while, so I totally understand if you'd prefer not to accept a change of this magnitude for a use-case that is a little on the specific side. Also more than glad to do any cleaning if you think it might be suitable with some polish; in particular it took me a little bit to get my head around the tests.

Thanks!
